### PR TITLE
RelativeTime plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,12 @@
 
 Provides `dayjs 1.11.5` for Deno.
 
-Day.js is a minimalist JavaScript library that parses, validates, manipulates,
-and displays dates and times for modern browsers with a largely
-Moment.js-compatible API. If you use Moment.js, you already know how to use
-Day.js.
+Day.js is a minimalist JavaScript library that parses, validates, manipulates, and displays dates and times for
+modern browsers with a largely Moment.js-compatible API. If you use Moment.js, you already know how to use Day.js.
 
-More info or API to see [this way](https://deno.land/x/dayjs).
+More info or API [here](https://deno.land/x/dayjs).
 
-## example
+## Example
 
 ```ts
 import dayjs from "https://deno.land/x/deno_dayjs@v0.2.2/mod.ts";
@@ -23,16 +21,32 @@ console.log(dayjs().endOf("date").format("YYYY-MM-DD HH:mm:ss"));
 console.log(dayjs("20211027").endOf("date").format("YYYY-MM-DD HH:mm:ss"));
 ```
 
-use plugin, but now just one `weekOfYear` which is my need.
+# Plugins
+
+> You can also get the URL from cdn yourself like: `https://esm.sh/dayjs@1.11.3/plugin/<pluginName>`.
+
+## Week of year
 
 ```ts
 import dayjs from "https://deno.land/x/deno_dayjs@v0.2.2/mod.ts";
-import { weekOfYear } from "https://deno.land/x/deno_dayjs@v0.2.2/plugin/weekOfYear.ts";
+import weekOfYear from "https://deno.land/x/deno_dayjs@v0.2.2/plugin/weekOfYear.ts";
 dayjs.extend(weekOfYear);
 
 const date = dayjs(day);
 console.log(date.year() + "-" + date.week());
 ```
 
-You can also get the URL from cdn yourself like:
-`https://esm.sh/dayjs@1.11.3/plugin/weekOfYear`.
+## Relative Time
+
+```ts
+import dayjs from "https://deno.land/x/deno_dayjs@v0.2.2/mod.ts";
+import relativeTime from "https://deno.land/x/deno_dayjs@v0.2.2/plugin/relativeTime.ts";
+dayjs.extend(relativeTime);
+
+dayjs().from(dayjs("1990-01-01")); // in 33 years
+dayjs().from(dayjs("1990-01-01"), true); // 33 years
+dayjs().fromNow();
+
+dayjs().to(dayjs("1990-01-01")); // "33 years ago"
+dayjs().toNow();
+```

--- a/example.ts
+++ b/example.ts
@@ -27,11 +27,11 @@ console.log(getYearAndWeek(new Date()));
 dayjs.extend(relativeTime);
 {
   const results = {
-    from: dayjs().from(dayjs("1990-01-01")), // in 31 years
-    fromTrue: dayjs().from(dayjs("1990-01-01"), true), // 31 years
+    from: dayjs().from(dayjs("1990-01-01")), // in 33 years
+    fromTrue: dayjs().from(dayjs("1990-01-01"), true), // 33 years
     fromNow: dayjs().fromNow(),
 
-    to: dayjs().to(dayjs("1990-01-01")), // "31 years ago"
+    to: dayjs().to(dayjs("1990-01-01")), // "33 years ago"
     toNow: dayjs().toNow(),
   };
 

--- a/example.ts
+++ b/example.ts
@@ -1,7 +1,7 @@
 import dayjs from "./mod.ts";
 // use plugin
-import { weekOfYear } from "./plugin/weekOfYear.ts";
-dayjs.extend(weekOfYear);
+import weekOfYear from "./plugin/weekOfYear.ts";
+import relativeTime from "./plugin/relativeTime.ts";
 
 const day = dayjs().format("YYYY-MM-DD HH:mm:ss");
 console.log(day);
@@ -19,6 +19,21 @@ export function getYearAndWeek(day: string | Date) {
   const date = dayjs(day);
   return date.year() + "-" + date.week();
 }
+dayjs.extend(weekOfYear);
 
 console.log(getYearAndWeek("2021-11-24"));
 console.log(getYearAndWeek(new Date()));
+
+dayjs.extend(relativeTime);
+{
+  const results = {
+    from: dayjs().from(dayjs("1990-01-01")), // in 31 years
+    fromTrue: dayjs().from(dayjs("1990-01-01"), true), // 31 years
+    fromNow: dayjs().fromNow(),
+
+    to: dayjs().to(dayjs("1990-01-01")), // "31 years ago"
+    toNow: dayjs().toNow(),
+  };
+
+  console.table(results);
+}

--- a/plugin/relativeTime.d.ts
+++ b/plugin/relativeTime.d.ts
@@ -1,0 +1,13 @@
+import { PluginFunc } from "../index.d.ts";
+
+declare const plugin: PluginFunc;
+export default plugin;
+
+declare module "../index.d.ts" {
+  export interface Dayjs {
+    fromNow(withoutSufix?: boolean): string;
+    from(compared: Dayjs, withoutSuffix?: boolean): string;
+    toNow(withoutSuffix?: boolean): string;
+    to(compared: Dayjs, withoutSuffix?: boolean): string;
+  }
+}

--- a/plugin/relativeTime.ts
+++ b/plugin/relativeTime.ts
@@ -1,0 +1,5 @@
+// @deno-types="./relativeTime.d.ts"
+import relativeTime from "https://esm.sh/v85/dayjs@1.11.3/es2022/plugin/relativeTime.js";
+
+export { relativeTime };
+export default relativeTime;

--- a/plugin/weekOfYear.ts
+++ b/plugin/weekOfYear.ts
@@ -2,3 +2,4 @@
 import weekOfYear from "https://esm.sh/v85/dayjs@1.11.3/es2022/plugin/weekOfYear.js";
 
 export { weekOfYear };
+export default weekOfYear;


### PR DESCRIPTION
![image](https://github.com/jiawei397/deno_dayjs/assets/12930717/3d586b05-f247-4aa4-87c6-f2e0cc62357a)
![image](https://github.com/jiawei397/deno_dayjs/assets/12930717/a337de2e-9a2f-4ad5-bad7-36c9e27c050b)

# deno_dayjs

Provides `dayjs 1.11.5` for Deno.

Day.js is a minimalist JavaScript library that parses, validates, manipulates, and displays dates and times for
modern browsers with a largely Moment.js-compatible API. If you use Moment.js, you already know how to use Day.js.

More info or API [here](https://deno.land/x/dayjs).

## Example

```ts
import dayjs from "https://deno.land/x/deno_dayjs@v0.2.2/mod.ts";

const day = dayjs().format("YYYY-MM-DD HH:mm:ss");
console.log(day);

console.log(dayjs().startOf("date").toDate());
console.log(dayjs().startOf("date").format("YYYY-MM-DD HH:mm:ss"));
console.log(dayjs().endOf("date").format("YYYY-MM-DD HH:mm:ss"));
console.log(dayjs("20211027").endOf("date").format("YYYY-MM-DD HH:mm:ss"));
```

# Plugins

> You can also get the URL from cdn yourself like: `https://esm.sh/dayjs@1.11.3/plugin/<pluginName>`.

## Week of year

```ts
import dayjs from "https://deno.land/x/deno_dayjs@v0.2.2/mod.ts";
import weekOfYear from "https://deno.land/x/deno_dayjs@v0.2.2/plugin/weekOfYear.ts";
dayjs.extend(weekOfYear);

const date = dayjs(day);
console.log(date.year() + "-" + date.week());
```

## Relative Time

```ts
import dayjs from "https://deno.land/x/deno_dayjs@v0.2.2/mod.ts";
import relativeTime from "https://deno.land/x/deno_dayjs@v0.2.2/plugin/relativeTime.ts";
dayjs.extend(relativeTime);

dayjs().from(dayjs("1990-01-01")); // in 33 years
dayjs().from(dayjs("1990-01-01"), true); // 33 years
dayjs().fromNow();

dayjs().to(dayjs("1990-01-01")); // "33 years ago"
dayjs().toNow();
```