### PR TITLE
feat: using dayjs@1.11.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 Provides `dayjs 1.11.5` for Deno.
 
-Day.js is a minimalist JavaScript library that parses, validates, manipulates, and displays dates and times for
-modern browsers with a largely Moment.js-compatible API. If you use Moment.js, you already know how to use Day.js.
+Day.js is a minimalist JavaScript library that parses, validates, manipulates,
+and displays dates and times for modern browsers with a largely
+Moment.js-compatible API. If you use Moment.js, you already know how to use
+Day.js.
 
 More info or API [here](https://deno.land/x/dayjs).
 
@@ -23,7 +25,8 @@ console.log(dayjs("20211027").endOf("date").format("YYYY-MM-DD HH:mm:ss"));
 
 # Plugins
 
-> You can also get the URL from cdn yourself like: `https://esm.sh/dayjs@1.11.3/plugin/<pluginName>`.
+> You can also get the URL from cdn yourself like:
+> `https://esm.sh/dayjs@1.11.5/plugin/<pluginName>`.
 
 ## Week of year
 

--- a/deno.lock
+++ b/deno.lock
@@ -1,9 +1,9 @@
 {
   "version": "2",
   "remote": {
-    "https://esm.sh/v85/dayjs@1.11.3/es2022/plugin/relativeTime.js": "0bcbed3fb9ea5c86e0a9a7b070aa20d06ddc6a0cd1d4dca9e37f72a9b0662f1a",
-    "https://esm.sh/v85/dayjs@1.11.3/es2022/plugin/utc.js": "d02abbc6b668d8eaa31c0b047db9c9ee0e82b90adf699c533759ae0bd312558a",
-    "https://esm.sh/v85/dayjs@1.11.3/es2022/plugin/weekOfYear.js": "433257ede12fa9c2ed046c2364fb460742a15219606bd5e30828680a3804d8f7",
-    "https://esm.sh/v96/dayjs@1.11.5/es2022/dayjs.js": "f74890f67c30d4768b652c95fb42ffed869ce2fb41c813347aa178490e136785"
+    "https://esm.sh/v85/dayjs@1.11.5/es2022/plugin/relativeTime.js": "10d768091b2927c0cf4f93df33ca80de40e454b270a4fd336d1b40e475273f04",
+    "https://esm.sh/v85/dayjs@1.11.5/es2022/plugin/utc.js": "045ed871ed7594da98e16db269cd1fa7c4d09854ac05714052dc29df29686d83",
+    "https://esm.sh/v85/dayjs@1.11.5/es2022/plugin/weekOfYear.js": "e98c0be360bb045a602be2d90da1364f25ac18bd795142a7865f30c4186c54a4",
+    "https://esm.sh/v96/dayjs@1.11.5/es2022/dayjs.mjs": "62c5c11c07adf3d55398171043b6691559df07a1c406064f9ea1c8877bbeb643"
   }
 }

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,5 @@
 // @deno-types="./index.d.ts"
-import dayjs from "https://esm.sh/v96/dayjs@1.11.5/es2022/dayjs.js";
+import dayjs from "https://esm.sh/v96/dayjs@1.11.5/es2022/dayjs.mjs";
 
 export default dayjs;
 

--- a/plugin/relativeTime.ts
+++ b/plugin/relativeTime.ts
@@ -1,5 +1,5 @@
 // @deno-types="./relativeTime.d.ts"
-import relativeTime from "https://esm.sh/v85/dayjs@1.11.3/es2022/plugin/relativeTime.js";
+import relativeTime from "https://esm.sh/v85/dayjs@1.11.5/es2022/plugin/relativeTime.js";
 
 export { relativeTime };
 export default relativeTime;

--- a/plugin/utc.ts
+++ b/plugin/utc.ts
@@ -1,5 +1,5 @@
 // @deno-types="./utc.d.ts"
-import utc from "https://esm.sh/v85/dayjs@1.11.3/es2022/plugin/utc.js";
+import utc from "https://esm.sh/v85/dayjs@1.11.5/es2022/plugin/utc.js";
 
 export { utc };
 export default utc;

--- a/plugin/weekOfYear.ts
+++ b/plugin/weekOfYear.ts
@@ -1,5 +1,5 @@
 // @deno-types="./weekOfYear.d.ts"
-import weekOfYear from "https://esm.sh/v85/dayjs@1.11.3/es2022/plugin/weekOfYear.js";
+import weekOfYear from "https://esm.sh/v85/dayjs@1.11.5/es2022/plugin/weekOfYear.js";
 
 export { weekOfYear };
 export default weekOfYear;


### PR DESCRIPTION
Using the latest dayjs version which is 1.11.5.
Also use `dayjs.mjs` file instead of `dayjs.js`, because `dayjs.js` file is missing.